### PR TITLE
Rounding eut before displaying on the screen

### DIFF
--- a/vacuum_reactors.lua
+++ b/vacuum_reactors.lua
@@ -923,7 +923,7 @@ local function create_widgets(lsc, reactors)
             local yy = widget.min_y + 2
             local reactors = widget.reactors
             for _, reactor in ipairs(reactors) do
-                local eut = reactor.output_eut
+                local eut = math.floor(reactor.output_eut)
                 local heat_pct = math.floor(reactor.current_heat / reactor.max_heat * 100)
                 local enabled = reactor.enabled and "☑" or "☐"
                 local status = reactor.status


### PR DESCRIPTION
I've been using a reactor control program with a standard reactor component diagram for some time. After some time I ran out of uranium and replaced the uranium fuel rods with thorium fuel rods and an error occurred a few seconds after startup:

![image](https://github.com/user-attachments/assets/9e13f562-2f83-4127-95e7-d4ce2d9093d9)

I was able to solve this problem by rounding the eut value received from the reactor before displaying it on the control computer screen